### PR TITLE
fixing the sendable

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,6 +39,7 @@ playground.xcworkspace
 # Package.pins
 # Package.resolved
 .build/
+.swiftpm/
 
 # CocoaPods
 #

--- a/Sources/PerfectNIO/HTTPOutput/ErrorOutput.swift
+++ b/Sources/PerfectNIO/HTTPOutput/ErrorOutput.swift
@@ -20,7 +20,7 @@ import Foundation
 import NIOHTTP1
 
 /// Output which can be thrown
-public class ErrorOutput: BytesOutput, Error, CustomStringConvertible {
+public class ErrorOutput: BytesOutput, Error, CustomStringConvertible, @unchecked Sendable {
 	public let description: String
 	/// Construct a ErrorOutput with a simple text message
 	public init(status: HTTPResponseStatus, description: String? = nil) {

--- a/Sources/PerfectNIO/RouteServer.swift
+++ b/Sources/PerfectNIO/RouteServer.swift
@@ -95,7 +95,7 @@ class NIOBoundRoutes: BoundRoutes {
 	private static func configureHTTPServerPipeline(pipeline: ChannelPipeline, sslContext: NIOSSLContext?) -> EventLoopFuture<Void> {
 		var handlers: [ChannelHandler] = []
 		if let sslContext = sslContext {
-			let handler = try! NIOSSLServerHandler(context: sslContext)
+			let handler = NIOSSLServerHandler(context: sslContext)
 			handlers.append(handler)
 			handlers.append(SSLFileRegionHandler())
 		}


### PR DESCRIPTION
The `ErrorOutput` has a conflict with NSObject `Sendable`.

All tests passed on macOS / M1